### PR TITLE
Setting defaults for loggly and borda reporting

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
 hash: 7ff802068e35c524b6091ccc5e53b82072a72b664a302c23e6b3c9b9b5a5cc3d
-updated: 2016-08-30T06:03:37.80415443-05:00
+updated: 2016-09-27T10:30:23.487986251-05:00
 imports:
 - name: git.torproject.org/pluggable-transports/goptlib.git
-  version: 15d8df1cd780ddb0bb1710b08a5546f2a8f027bf
+  version: 50915b3ba5ee27c0b2fcdad9edd51156fb55192c
 - name: git.torproject.org/pluggable-transports/obfs4.git
   version: 62057625eaba2a555967b9615039d43dda071360
   subpackages:
@@ -20,15 +20,15 @@ imports:
   - extra25519
   - edwards25519
 - name: github.com/armon/go-socks5
-  version: b34cad17d2fdbb038116de97a36d76995393b87a
+  version: e75332964ef517daa070d7c38a9466a0d687e0a5
 - name: github.com/blang/semver
   version: 60ec3488bfea7cca02b021d106d9911120d25fe9
 - name: github.com/davecgh/go-spew
-  version: 6cf5744a041a0022271cefed95ba843f6d87fd51
+  version: 6d212800a42e8ab5c146b8ace3490ee17e5225f9
   subpackages:
   - spew
 - name: github.com/dchest/siphash
-  version: 6d8617816bb5d8268011ffbfb8720f17ce9af63c
+  version: 4ebf1de738443ea7f45f02dc394c4df1942a126d
 - name: github.com/fatih/set
   version: 27c40922c40b43fe04554d8223a402af3ea333f3
 - name: github.com/getlantern/appdir
@@ -40,11 +40,11 @@ imports:
 - name: github.com/getlantern/bandwidth
   version: 96de96fff16cf1aa844edc1b4a72c906add83180
 - name: github.com/getlantern/borda
-  version: 6af58869de1e413c24bda8582a25335e389c19e4
+  version: 49d716c6f0a075c94b1fd449bd6aebed8d48a5b1
   subpackages:
   - client
 - name: github.com/getlantern/byteexec
-  version: 61c05c54847bc0130938da161dc45178a4acfea4
+  version: 2e21fedeb225921a8dc40321cbd114ffd0a302f3
 - name: github.com/getlantern/chained
   version: 333b0f12504a0ddb5f2680117c190843d931bec4
 - name: github.com/getlantern/context
@@ -58,11 +58,10 @@ imports:
 - name: github.com/getlantern/filepersist
   version: c5f0cd24e7991579ba6f5f1bd20a1ad2c9f06cd4
 - name: github.com/getlantern/flashlight
-  version: 2ac993ad3a155d45a3968c0b5a5287e3976fd95a
+  version: f1f6d4abae61527e4b58d071e1fa6bfce2fbccd9
   subpackages:
   - client
   - config
-  - feed
   - logging
   - proxied
   - geolookup
@@ -77,7 +76,7 @@ imports:
 - name: github.com/getlantern/go-loggly
   version: d15e28ab7389ed5d644ccb891d9d54154e43cd27
 - name: github.com/getlantern/go-update
-  version: cb048f77e108c397a3c19752bf7778ea4bae2dc7
+  version: 1904ad695e9016db58b7e9038420d90a022ae4ea
   subpackages:
   - check
   - download
@@ -96,7 +95,7 @@ imports:
   subpackages:
   - certimporter
 - name: github.com/getlantern/netx
-  version: dd9af75d5bfdc86fa35f3aeadb42945db1c1e56a
+  version: 70375a276c57e76c1fe1e2fbdb4c2d2714a67b39
 - name: github.com/getlantern/ops
   version: b70875f5d689a9438bca72aefd7142a2af889b18
 - name: github.com/getlantern/osversion
@@ -110,7 +109,7 @@ imports:
 - name: github.com/getlantern/proxiedsites
   version: 996122c1374578a85a536445d7d7ae88d3ee5a35
 - name: github.com/getlantern/proxybench
-  version: 79964216eee9a91ae6d162b1bc832308289c794a
+  version: 85123f728631103f1d899081671040a9cd4beb3d
 - name: github.com/getlantern/rot13
   version: 33f93fc1fe85c042c0667a1814e6379bd5e7eb40
 - name: github.com/getlantern/rotator
@@ -138,17 +137,17 @@ imports:
 - name: github.com/oxtoacart/bpool
   version: 4e1c5567d7c2dd59fa4c7c83d34c2f3528b025d6
 - name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
+  version: 976c720a22c8eb4eb6a0b4348ad85ad12491a506
   subpackages:
   - assert
 - name: github.com/stripe/stripe-go
-  version: d597304dd1308b7b5587b3aee4671b5b4591b7a8
+  version: b51c93a81e8ddf4ad924225fe85eae1020ccc7ca
   subpackages:
   - orderitem
 - name: github.com/visionmedia/go-debug
   version: ff4a55a20a86994118644bbddc6a216da193cc13
 - name: golang.org/x/crypto
-  version: 351dc6a5bf92a5f2ae22fadeee08eb6a45aa2d93
+  version: 8e06e8ddd9629eb88639aba897641bff8031f1d3
   subpackages:
   - curve25519
   - hkdf
@@ -156,7 +155,7 @@ imports:
   - poly1305
   - salsa20/salsa
 - name: golang.org/x/net
-  version: 6250b412798208e6c90b03b7c4f226de5aa299e2
+  version: f09c4662a0bd6bd8943ac7b4931e185df9471da4
   subpackages:
   - context
 devImports: []

--- a/lantern.go
+++ b/lantern.go
@@ -131,8 +131,12 @@ func (uc *userConfig) GetUserID() int64 {
 }
 
 func run(configDir string, user UserConfig) {
-	flags := make(map[string]interface{})
-	flags["staging"] = false
+	flags := map[string]interface{}{
+		"borda-report-interval":    5 * time.Minute,
+		"borda-sample-percentage":  float64(0.01),
+		"loggly-sample-percentage": float64(0.02),
+		"staging":                  false,
+	}
 
 	err := os.MkdirAll(configDir, 0755)
 	if os.IsExist(err) {
@@ -140,8 +144,8 @@ func run(configDir string, user UserConfig) {
 		return
 	}
 
-	if err := logging.EnableFileLogging(configDir); err != nil {
-		log.Errorf("Unable to enable file logging: %v", err)
+	if logErr := logging.EnableFileLogging(configDir); logErr != nil {
+		log.Errorf("Unable to enable file logging: %v", logErr)
 		return
 	}
 	log.Debugf("Writing log messages to %s/lantern.log", configDir)
@@ -153,12 +157,17 @@ func run(configDir string, user UserConfig) {
 		log.Errorf("Error parsing boolean flag: %v", err)
 	}
 
+	// Need to manually enable logging since we don't have settings in Mobile
+	// TODO: allow configuring whether or not to enable reporting (just like we
+	// already have in desktop)
+	logging.SetReportingEnabled(true)
+
 	flashlight.Run("127.0.0.1:0", // listen for HTTP on random address
 		"127.0.0.1:0", // listen for SOCKS on random address
 		configDir,     // place to store lantern configuration
 		false,         // don't make config sticky
-		func() bool { return true },  // proxy all requests
-		make(map[string]interface{}), // no special configuration flags
+		func() bool { return true }, // proxy all requests
+		flags,
 		func() bool {
 			beforeStart(user)
 			return true

--- a/lantern_pro.go
+++ b/lantern_pro.go
@@ -266,7 +266,13 @@ func ProRequest(shouldProxy bool, command string, session Session) bool {
 		"cancel":      cancel,
 	}
 
-	res, err := commands[command](req)
+	cmd, cmdFound := commands[command]
+	if !cmdFound {
+		session.SetError(command, "Command not found")
+		return false
+	}
+
+	res, err := cmd(req)
 	if err != nil || res.Status != "ok" {
 		log.Errorf("Error making %s request to Pro server: %v response: %v", command, err, res)
 		if res != nil {


### PR DESCRIPTION
This initializes default borda and loggly settings which would usually come from the command-line (which of course isn't present in mobile).

This other PR will allow us to reconfigure this on the fly - https://github.com/getlantern/flashlight/pull/82